### PR TITLE
Allow PHP 8.x.x to be used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": "^7.1.8",
+    "php": "^7.1.8 || ^8.0.0",
     "nesbot/carbon": "~2",
     "ext-json": "*",
     "ext-curl": "*"


### PR DESCRIPTION
I've been testing out the API on PHP8.0.0, everything seems to be working. This is currently blocking my automated pipelines, as it now requires a --ignore-platform-reqs to install.